### PR TITLE
fix: 페이지별 성과 차트 렌더링 에러

### DIFF
--- a/src/featured/traffic/components/PerformanceChart.tsx
+++ b/src/featured/traffic/components/PerformanceChart.tsx
@@ -73,8 +73,8 @@ export function PerformanceChartContent({ data }: PerformanceChartProps) {
   }
 
   const chartData = data.map((item) => ({
-    name: shortenPath(item.routePage),
-    fullPath: item.routePage,
+    name: shortenPath(item.pagePath),
+    fullPath: item.pagePath,
     pageViews: item.pageViews,
     activeUsers: item.activeUsers,
     avgDuration: item.activeUsers > 0 ? Math.round(item.userDurations / item.activeUsers) : 0,

--- a/src/featured/traffic/components/PerformanceChart.tsx
+++ b/src/featured/traffic/components/PerformanceChart.tsx
@@ -24,7 +24,8 @@ function formatTime(seconds: number): string {
   return `${minutes}분 ${remainSeconds}초`
 }
 
-function shortenPath(path: string): string {
+function shortenPath(path?: string): string {
+  if (!path) return '' // null이나 undefined일 경우 빈 문자열 반환
   if (path.length <= 22) return path
   return '…' + path.slice(-19)
 }


### PR DESCRIPTION
## 변경 사항

- `PerformanceChart.tsx` 내 데이터 매핑 오타 수정 (`item.routePage` -> `item.pagePath`)
-  `shortenPath` 함수에 예외 처리(방어 코드) 추가

## 리뷰 필요

- PerformanceChart.tsx


close #19 