### PR TITLE
feat: ga4) 리포트 대기중 탭 전환 로직 추가 및 ui 구현 

### DIFF
--- a/src/featured/traffic/components/FrictionBoard.tsx
+++ b/src/featured/traffic/components/FrictionBoard.tsx
@@ -14,6 +14,8 @@ const getUxDesc = (title: string) => {
   if (title.includes('질문 생성')) return '질문 생성 대기 중 지루함을 느껴 뒤로가기 또는 이탈 발생'
   if (title.includes('리포트 분석'))
     return '분석 중 화면이 멈춘 것으로 오해하여 새로고침 또는 이탈 발생'
+  if (title.includes('비활성 탭')) return '대기 시간이 길어 지루함을 느끼고 다른 탭으로 시선을 돌림'
+
   return '화면 대기 중 사용자가 피로도를 느껴 이탈했습니다.'
 }
 
@@ -24,8 +26,7 @@ export function FrictionBoard({ data }: FrictionBoardProps) {
       <div className="mb-6 shrink-0">
         <h2 className="text-foreground text-xl font-bold">AI 분석 대기 이탈 top3 </h2>
         <p className="text-muted-foreground mt-1.5 text-sm break-keep">
-          가장 이탈이 심한 화면을 순위로 노출하여, 다음 스프린트의 최우선 해결 과제로
-          삼습니다.
+          가장 이탈이 심한 화면을 순위로 노출하여, 다음 스프린트의 최우선 해결 과제로 삼습니다.
         </p>
       </div>
 

--- a/src/featured/traffic/components/FrictionBoard.tsx
+++ b/src/featured/traffic/components/FrictionBoard.tsx
@@ -14,8 +14,7 @@ const getUxDesc = (title: string) => {
   if (title.includes('질문 생성')) return '질문 생성 대기 중 지루함을 느껴 뒤로가기 또는 이탈 발생'
   if (title.includes('리포트 분석'))
     return '분석 중 화면이 멈춘 것으로 오해하여 새로고침 또는 이탈 발생'
-  if (title.includes('비활성 탭')) return '대기 시간이 길어 지루함을 느끼고 다른 탭으로 시선을 돌림'
-
+  if (title.includes('화면 이탈')) return '대기 시간이 길어 지루함을 느끼고 다른 탭으로 시선을 돌림'
   return '화면 대기 중 사용자가 피로도를 느껴 이탈했습니다.'
 }
 
@@ -24,7 +23,7 @@ export function FrictionBoard({ data }: FrictionBoardProps) {
     <div className="border-border bg-card flex h-full flex-col rounded-2xl border p-6">
       {/* 헤더 영역 */}
       <div className="mb-6 shrink-0">
-        <h2 className="text-foreground text-xl font-bold">AI 분석 대기 이탈 top3 </h2>
+        <h2 className="text-foreground text-xl font-bold">AI 대기 구간 유저 마찰 지표 Top 3 </h2>
         <p className="text-muted-foreground mt-1.5 text-sm break-keep">
           가장 이탈이 심한 화면을 순위로 노출하여, 다음 스프린트의 최우선 해결 과제로 삼습니다.
         </p>

--- a/src/featured/traffic/components/FrictionBoard.tsx
+++ b/src/featured/traffic/components/FrictionBoard.tsx
@@ -22,9 +22,9 @@ export function FrictionBoard({ data }: FrictionBoardProps) {
     <div className="border-border bg-card flex h-full flex-col rounded-2xl border p-6">
       {/* 헤더 영역 */}
       <div className="mb-6 shrink-0">
-        <h2 className="text-foreground text-xl font-bold">UX 마찰 랭킹 리스트</h2>
+        <h2 className="text-foreground text-xl font-bold">AI 분석 대기 이탈 top3 </h2>
         <p className="text-muted-foreground mt-1.5 text-sm break-keep">
-          가장 마찰(이탈)이 심한 화면을 순위제로 노출하여, 다음 스프린트의 최우선 해결 과제로
+          가장 이탈이 심한 화면을 순위로 노출하여, 다음 스프린트의 최우선 해결 과제로
           삼습니다.
         </p>
       </div>

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -69,6 +69,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
               'question_gen_complete',
               'report_gen_start',
               'report_gen_complete',
+              'loading_tab_leave',
             ],
           },
         },
@@ -80,6 +81,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       question_gen_complete: 0,
       report_gen_start: 0,
       report_gen_complete: 0,
+      loading_tab_leave: 0,
     }
 
     response.rows?.forEach((row) => {

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -91,8 +91,13 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       }
     })
 
+    // 기존 계산식 (시작 대비 완료율로 이탈 계산)
     const calcDropOff = (start: number, complete: number) =>
       start > 0 ? Number((((start - complete) / start) * 100).toFixed(1)) : 0
+
+    // 탭 이탈률 전용 계산식 추가 (탭 나간 수 / 전체 로딩 시작 수)
+    const calcTabLeaveRate = (start: number, leaveCount: number) =>
+      start > 0 ? Number(((leaveCount / start) * 100).toFixed(1)) : 0
 
     const rankings: FrictionRanking[] = [
       {
@@ -105,6 +110,12 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
         title: '면접 후 AI 리포트 분석',
         dropOffRate: calcDropOff(counts.report_gen_start, counts.report_gen_complete),
       },
+      {
+        id: 3, 
+        title: '비활성 탭 전환 (지루함)',
+        dropOffRate: calcTabLeaveRate(counts.report_gen_start, counts.loading_tab_leave),
+      },
+      // 나중에 초단기 이탈(id: 4), 분노의 클릭(id: 5)도 추가 예정
     ]
 
     return rankings.sort((a, b) => b.dropOffRate - a.dropOffRate)

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -112,7 +112,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       },
       {
         id: 3,
-        title: '비활성 탭 전환 (지루함)',
+        title: '리포트 대기 중 화면 이탈',
         dropOffRate: calcTabLeaveRate(counts.report_gen_start, counts.loading_tab_leave),
       },
       // 나중에 초단기 이탈(id: 4), 분노의 클릭(id: 5)도 추가 예정

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -95,7 +95,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
     const calcDropOff = (start: number, complete: number) =>
       start > 0 ? Number((((start - complete) / start) * 100).toFixed(1)) : 0
 
-    // 탭 이탈률 전용 계산식 추가 (탭 나간 수 / 전체 로딩 시작 수)
+    // 탭 이탈률 계산 추가 (탭 나간 수 / 전체 로딩 시작 수)
     const calcTabLeaveRate = (start: number, leaveCount: number) =>
       start > 0 ? Number(((leaveCount / start) * 100).toFixed(1)) : 0
 
@@ -111,14 +111,14 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
         dropOffRate: calcDropOff(counts.report_gen_start, counts.report_gen_complete),
       },
       {
-        id: 3, 
+        id: 3,
         title: '비활성 탭 전환 (지루함)',
         dropOffRate: calcTabLeaveRate(counts.report_gen_start, counts.loading_tab_leave),
       },
       // 나중에 초단기 이탈(id: 4), 분노의 클릭(id: 5)도 추가 예정
     ]
 
-    return rankings.sort((a, b) => b.dropOffRate - a.dropOffRate)
+    return rankings.sort((a, b) => b.dropOffRate - a.dropOffRate).slice(0, 3)
   } catch (error) {
     // 3. 에러 발생 시 로그를 남기고 빈 배열을 반환해 UI 렌더링 중단을 방지합니다
     console.error('GA4 마찰 지수 데이터 호출 에러:', error)


### PR DESCRIPTION
## 변경 사항

- Traffic.service.ts에 탭 이탈률 계산 로직 추가 및 Top 3 랭킹 필터링(slice) 적용

- FrictionBoard.tsx 내 탭 이탈 마찰 지표 설명(getUxDesc) 추가

## 리뷰 필요

- 데이터 잘 수집되어서 ui 에 잘 나타나는지 

close #26 