### PR TITLE
feat : 분노의클릭 마찰율 ui 구현 

### DIFF
--- a/src/featured/traffic/components/FrictionBoard.tsx
+++ b/src/featured/traffic/components/FrictionBoard.tsx
@@ -15,6 +15,7 @@ const getUxDesc = (title: string) => {
   if (title.includes('리포트 분석'))
     return '분석 중 화면이 멈춘 것으로 오해하여 새로고침 또는 이탈 발생'
   if (title.includes('화면 이탈')) return '대기 시간이 길어 지루함을 느끼고 다른 탭으로 시선을 돌림'
+  if (title.includes('분노의 클릭')) return 'AI 리포트 발행 대기 중 반복 클릭이 발생'
   return '화면 대기 중 사용자가 피로도를 느껴 이탈했습니다.'
 }
 

--- a/src/featured/traffic/components/FrictionBoard.tsx
+++ b/src/featured/traffic/components/FrictionBoard.tsx
@@ -79,7 +79,7 @@ export function FrictionBoard({ data }: FrictionBoardProps) {
                   className={`ml-3 flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-bold ${badgeClass}`}
                 >
                   <Icon className="h-3.5 w-3.5" aria-hidden="true" strokeWidth={2.5} />
-                  {stat.dropOffRate}% 이탈률
+                  {stat.dropOffRate}% {stat.rateLabel ?? '이탈률'}
                 </div>
               </motion.div>
             )

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -148,7 +148,7 @@ export async function getRageClickRate() {
         filter: {
           fieldName: 'eventName',
           inListFilter: {
-            values: ['report_waiting_session', 'rage_click'],
+            values: ['report_waiting_session', 'report_waiting_rage_click'],
           },
         },
       },
@@ -168,7 +168,7 @@ export async function getRageClickRate() {
         waitingReportIds.add(reportId)
       }
 
-      if (eventName === 'rage_click') {
+      if (eventName === 'report_waiting_rage_click') {
         rageClickReportIds.add(reportId)
       }
     })

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -56,26 +56,32 @@ export async function getPagePerformance() {
 // 이탈 랭킹 서비스 함수 추가 - GA4 이벤트 데이터를 기반으로 마찰 지수 계산
 export async function getFrictionIndex(): Promise<FrictionRanking[]> {
   try {
-    const [response] = await client.runReport({
-      property: `properties/${propertyId}`,
-      dateRanges: gaDateRanges,
-      dimensions: [{ name: 'eventName' }],
-      metrics: [{ name: 'eventCount' }],
-      dimensionFilter: {
-        filter: {
-          fieldName: 'eventName',
-          inListFilter: {
-            values: [
-              'question_gen_start',
-              'question_gen_complete',
-              'report_gen_start',
-              'report_gen_complete',
-              'loading_tab_leave',
-            ],
+    const [
+      [response], // client.runReport 결과 배열에서 response 꺼냄
+      rageClickRate, // getRageClickFrictionRate 결과 숫자
+    ] = await Promise.all([
+      client.runReport({
+        property: `properties/${propertyId}`,
+        dateRanges: gaDateRanges,
+        dimensions: [{ name: 'eventName' }],
+        metrics: [{ name: 'eventCount' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'eventName',
+            inListFilter: {
+              values: [
+                'question_gen_start',
+                'question_gen_complete',
+                'report_gen_start',
+                'report_gen_complete',
+                'loading_tab_leave',
+              ],
+            },
           },
         },
-      },
-    })
+      }),
+      getRageClickFrictionRate(),
+    ])
 
     const counts = {
       question_gen_start: 0,
@@ -99,8 +105,6 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
     // 탭 이탈률 계산 추가 (탭 나간 수 / 전체 로딩 시작 수)
     const calcTabLeaveRate = (start: number, leaveCount: number) =>
       start > 0 ? Number(((leaveCount / start) * 100).toFixed(1)) : 0
-
-    const rageClickRate = await getRageClickFrictionRate()
 
     const rankings: FrictionRanking[] = [
       {

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -12,6 +12,8 @@ const client = new BetaAnalyticsDataClient({
 
 const propertyId = process.env.GA_PROPERTY_ID
 const gaDateRanges = [{ startDate: '30daysAgo', endDate: 'today' }]
+// report_id별 이벤트 존재 여부를 계산하기 위해 충분히 넉넉한 row 수로 조회
+const GA_REPORT_ROW_LIMIT = 10000
 
 export async function getFirstUserChannel() {
   const [data] = await client.runReport({
@@ -157,7 +159,7 @@ export async function getRageClickFrictionRate() {
         },
       },
       // eventName + report_id 조합 row를 최대 10,000개까지 조회해 distinct report_id 계산 누락을 줄임
-      limit: 10000,
+      limit: GA_REPORT_ROW_LIMIT,
     })
 
     const waitingReportIds = new Set<string>()

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -60,7 +60,6 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       property: `properties/${propertyId}`,
       dateRanges: gaDateRanges,
       dimensions: [{ name: 'eventName' }],
-      // eventCount 숫자는 사용하지 않고, report_id가 해당 이벤트에 존재하는지만 확인
       metrics: [{ name: 'eventCount' }],
       dimensionFilter: {
         filter: {
@@ -136,7 +135,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
   }
 }
 
-// 대기 구간에서의 분노의 클릭률 계산 함수 추가
+// AI 리포트 대기 report_id 중 분노의 클릭이 발생한 report_id 비율 계산
 export async function getRageClickRate() {
   try {
     const [response] = await client.runReport({

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -156,6 +156,7 @@ export async function getRageClickFrictionRate() {
           },
         },
       },
+      // eventName + report_id 조합 row를 최대 10,000개까지 조회해 distinct report_id 계산 누락을 줄임
       limit: 10000,
     })
 

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -100,7 +100,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
     const calcTabLeaveRate = (start: number, leaveCount: number) =>
       start > 0 ? Number(((leaveCount / start) * 100).toFixed(1)) : 0
 
-    const rageClickRate = await getRageClickRate()
+    const rageClickRate = await getRageClickFrictionRate()
 
     const rankings: FrictionRanking[] = [
       {
@@ -136,7 +136,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
 }
 
 // AI 리포트 대기 report_id 중 분노의 클릭이 발생한 report_id 비율 계산
-export async function getRageClickRate() {
+export async function getRageClickFrictionRate() {
   try {
     const [response] = await client.runReport({
       property: `properties/${propertyId}`,

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -60,6 +60,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       property: `properties/${propertyId}`,
       dateRanges: gaDateRanges,
       dimensions: [{ name: 'eventName' }],
+      // eventCount 숫자는 사용하지 않고, report_id가 해당 이벤트에 존재하는지만 확인
       metrics: [{ name: 'eventCount' }],
       dimensionFilter: {
         filter: {
@@ -100,6 +101,8 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
     const calcTabLeaveRate = (start: number, leaveCount: number) =>
       start > 0 ? Number(((leaveCount / start) * 100).toFixed(1)) : 0
 
+    const rageClickRate = await getRageClickRate()
+
     const rankings: FrictionRanking[] = [
       {
         id: 1,
@@ -116,7 +119,13 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
         title: '리포트 대기 중 화면 이탈',
         dropOffRate: calcTabLeaveRate(counts.report_gen_start, counts.loading_tab_leave),
       },
-      // 나중에 초단기 이탈(id: 4), 분노의 클릭(id: 5)도 추가 예정
+      {
+        id: 4,
+        title: '리포트 대기중 분노의 클릭',
+        dropOffRate: rageClickRate,
+        rateLabel: '마찰률',
+      },
+      // 나중에 초단기 이탈(id: 5)도 추가 예정
     ]
 
     return rankings.sort((a, b) => b.dropOffRate - a.dropOffRate).slice(0, 3)
@@ -127,7 +136,8 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
   }
 }
 
-export async function getWaitingRageClickRate() {
+// 대기 구간에서의 분노의 클릭률 계산 함수 추가
+export async function getRageClickRate() {
   try {
     const [response] = await client.runReport({
       property: `properties/${propertyId}`,

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -125,3 +125,48 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
     return []
   }
 }
+
+export async function getWaitingRageClickRate() {
+  const [response] = await client.runReport({
+    property: `properties/${propertyId}`,
+    dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+    dimensions: [{ name: 'eventName' }, { name: 'customEvent:report_id' }],
+    // eventCount 값은 사용하지 않고, eventName + report_id 조합의 존재 여부만 distinct 계산에 사용
+    metrics: [{ name: 'eventCount' }],
+    dimensionFilter: {
+      filter: {
+        fieldName: 'eventName',
+        inListFilter: {
+          values: ['report_waiting_session', 'rage_click'],
+        },
+      },
+    },
+    limit: 10000,
+  })
+
+  const waitingReportIds = new Set<string>()
+  const rageClickReportIds = new Set<string>()
+
+  response.rows?.forEach((row) => {
+    const eventName = row.dimensionValues?.[0].value
+    const reportId = row.dimensionValues?.[1].value
+
+    if (!reportId || reportId === '(not set)') return
+
+    if (eventName === 'report_waiting_session') {
+      waitingReportIds.add(reportId)
+    }
+
+    if (eventName === 'rage_click') {
+      rageClickReportIds.add(reportId)
+    }
+  })
+
+  const rageClickedWaitingReportCount = [...waitingReportIds].filter((reportId) =>
+    rageClickReportIds.has(reportId),
+  ).length
+
+  return waitingReportIds.size > 0
+    ? Number(((rageClickedWaitingReportCount / waitingReportIds.size) * 100).toFixed(1))
+    : 0
+}

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -11,11 +11,12 @@ const client = new BetaAnalyticsDataClient({
 })
 
 const propertyId = process.env.GA_PROPERTY_ID
+const gaDateRanges = [{ startDate: '30daysAgo', endDate: 'today' }]
 
 export async function getFirstUserChannel() {
   const [data] = await client.runReport({
     property: `properties/${propertyId}`,
-    dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+    dateRanges: gaDateRanges,
     dimensions: [{ name: 'firstUserDefaultChannelGroup' }],
     metrics: [{ name: 'totalUsers' }],
   })
@@ -28,7 +29,7 @@ export async function getFirstUserChannel() {
 export async function getPagePerformance() {
   const [data] = await client.runReport({
     property: `properties/${propertyId}`,
-    dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+    dateRanges: gaDateRanges,
     dimensions: [{ name: 'pagePath' }],
     metrics: [
       { name: 'screenPageViews' },
@@ -57,7 +58,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
   try {
     const [response] = await client.runReport({
       property: `properties/${propertyId}`,
-      dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+      dateRanges: gaDateRanges,
       dimensions: [{ name: 'eventName' }],
       metrics: [{ name: 'eventCount' }],
       dimensionFilter: {
@@ -130,7 +131,7 @@ export async function getWaitingRageClickRate() {
   try {
     const [response] = await client.runReport({
       property: `properties/${propertyId}`,
-      dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+      dateRanges: gaDateRanges,
       dimensions: [{ name: 'eventName' }, { name: 'customEvent:report_id' }],
       // eventCount 값은 사용하지 않고, eventName + report_id 조합의 존재 여부만 distinct 계산에 사용
       metrics: [{ name: 'eventCount' }],

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -127,46 +127,51 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
 }
 
 export async function getWaitingRageClickRate() {
-  const [response] = await client.runReport({
-    property: `properties/${propertyId}`,
-    dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
-    dimensions: [{ name: 'eventName' }, { name: 'customEvent:report_id' }],
-    // eventCount 값은 사용하지 않고, eventName + report_id 조합의 존재 여부만 distinct 계산에 사용
-    metrics: [{ name: 'eventCount' }],
-    dimensionFilter: {
-      filter: {
-        fieldName: 'eventName',
-        inListFilter: {
-          values: ['report_waiting_session', 'rage_click'],
+  try {
+    const [response] = await client.runReport({
+      property: `properties/${propertyId}`,
+      dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
+      dimensions: [{ name: 'eventName' }, { name: 'customEvent:report_id' }],
+      // eventCount 값은 사용하지 않고, eventName + report_id 조합의 존재 여부만 distinct 계산에 사용
+      metrics: [{ name: 'eventCount' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'eventName',
+          inListFilter: {
+            values: ['report_waiting_session', 'rage_click'],
+          },
         },
       },
-    },
-    limit: 10000,
-  })
+      limit: 10000,
+    })
 
-  const waitingReportIds = new Set<string>()
-  const rageClickReportIds = new Set<string>()
+    const waitingReportIds = new Set<string>()
+    const rageClickReportIds = new Set<string>()
 
-  response.rows?.forEach((row) => {
-    const eventName = row.dimensionValues?.[0].value
-    const reportId = row.dimensionValues?.[1].value
+    response.rows?.forEach((row) => {
+      const eventName = row.dimensionValues?.[0].value
+      const reportId = row.dimensionValues?.[1].value
 
-    if (!reportId || reportId === '(not set)') return
+      if (!reportId || reportId === '(not set)') return
 
-    if (eventName === 'report_waiting_session') {
-      waitingReportIds.add(reportId)
-    }
+      if (eventName === 'report_waiting_session') {
+        waitingReportIds.add(reportId)
+      }
 
-    if (eventName === 'rage_click') {
-      rageClickReportIds.add(reportId)
-    }
-  })
+      if (eventName === 'rage_click') {
+        rageClickReportIds.add(reportId)
+      }
+    })
 
-  const rageClickedWaitingReportCount = [...waitingReportIds].filter((reportId) =>
-    rageClickReportIds.has(reportId),
-  ).length
+    const rageClickedWaitingReportCount = [...waitingReportIds].filter((reportId) =>
+      rageClickReportIds.has(reportId),
+    ).length
 
-  return waitingReportIds.size > 0
-    ? Number(((rageClickedWaitingReportCount / waitingReportIds.size) * 100).toFixed(1))
-    : 0
+    return waitingReportIds.size > 0
+      ? Number(((rageClickedWaitingReportCount / waitingReportIds.size) * 100).toFixed(1))
+      : 0
+  } catch (error) {
+    console.error('GA4 리포트 대기 분노의클릭 마찰률 데이터 호출 에러:', error)
+    return 0
+  }
 }

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -120,7 +120,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       },
       {
         id: 4,
-        title: '리포트 대기중 분노의 클릭',
+        title: '리포트 대기 중 분노의 클릭',
         dropOffRate: rageClickRate,
         rateLabel: '마찰률',
       },

--- a/src/featured/traffic/types/index.ts
+++ b/src/featured/traffic/types/index.ts
@@ -14,4 +14,5 @@ export type FrictionRanking = {
   id: number
   title: string
   dropOffRate: number
+  rateLabel?: '이탈률' | '마찰률'
 }


### PR DESCRIPTION
## 변경 사항

- GA4 조회 기간을 `gaDateRanges`로 공통화함 (30일 )
- 한 리포트에서 분노의 클릭이 여러 번 발생해도 1건으로 계산되도록 마찰률 집계 로직 추가 
- 분노의 클릭 항목은 UI에서 `마찰률` 라벨과 전용 설명 문구가 표시되도록 수정

## 리뷰 필요



close #30 