### PR TITLE
fix: "리포트 대기 중 화면 이탈" => "리포트 대기 중 화면 비활성화" 로 수정 

### DIFF
--- a/src/featured/traffic/components/FrictionBoard.tsx
+++ b/src/featured/traffic/components/FrictionBoard.tsx
@@ -14,7 +14,8 @@ const getUxDesc = (title: string) => {
   if (title.includes('질문 생성')) return '질문 생성 대기 중 지루함을 느껴 뒤로가기 또는 이탈 발생'
   if (title.includes('리포트 분석'))
     return '분석 중 화면이 멈춘 것으로 오해하여 새로고침 또는 이탈 발생'
-  if (title.includes('화면 이탈')) return '대기 시간이 길어 지루함을 느끼고 다른 탭으로 시선을 돌림'
+  if (title.includes('화면 비활성화'))
+    return '리포트 대기 중 다른 탭/앱 전환 또는 창 최소화로 대기 화면이 비활성화됨'
   if (title.includes('분노의 클릭')) return 'AI 리포트 발행 대기 중 반복 클릭이 발생'
   return '화면 대기 중 사용자가 피로도를 느껴 이탈했습니다.'
 }

--- a/src/featured/traffic/services/traffic.service.ts
+++ b/src/featured/traffic/services/traffic.service.ts
@@ -76,7 +76,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
                 'question_gen_complete',
                 'report_gen_start',
                 'report_gen_complete',
-                'loading_tab_leave',
+                'report_waiting_hidden',
               ],
             },
           },
@@ -90,7 +90,7 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       question_gen_complete: 0,
       report_gen_start: 0,
       report_gen_complete: 0,
-      loading_tab_leave: 0,
+      report_waiting_hidden: 0,
     }
 
     response.rows?.forEach((row) => {
@@ -104,9 +104,10 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
     const calcDropOff = (start: number, complete: number) =>
       start > 0 ? Number((((start - complete) / start) * 100).toFixed(1)) : 0
 
-    // 탭 이탈률 계산 추가 (탭 나간 수 / 전체 로딩 시작 수)
-    const calcTabLeaveRate = (start: number, leaveCount: number) =>
-      start > 0 ? Number(((leaveCount / start) * 100).toFixed(1)) : 0
+    // report_waiting_hidden은 리포트 대기 카드 노출 중 document.hidden === true가 된 경우 수집된다.
+    // 탭 전환, 앱 전환, 창 최소화, 화면 잠금 등으로 대기 화면이 background 상태가 된 경우를 포함한다.
+    const calcWaitingHiddenRate = (start: number, hiddenCount: number) =>
+      start > 0 ? Number(((hiddenCount / start) * 100).toFixed(1)) : 0
 
     const rankings: FrictionRanking[] = [
       {
@@ -121,8 +122,8 @@ export async function getFrictionIndex(): Promise<FrictionRanking[]> {
       },
       {
         id: 3,
-        title: '리포트 대기 중 화면 이탈',
-        dropOffRate: calcTabLeaveRate(counts.report_gen_start, counts.loading_tab_leave),
+        title: '리포트 대기 중 화면 비활성화',
+        dropOffRate: calcWaitingHiddenRate(counts.report_gen_start, counts.report_waiting_hidden),
       },
       {
         id: 4,


### PR DESCRIPTION
## 변경 사항

- GA4 조회 이벤트명 `loading_tab_leave` → `report_waiting_hidden`
- `counts` 집계 키 변경
- rankings 계산식에서 `counts.report_waiting_hidden` 사용
- 지표 타이틀 `리포트 대기 중 화면 비활성화`로 변경
- UX 설명 문구 변경
- `document.hidden === true` 기준임을 서비스 코드에 주석으로 명시

## 리뷰 필요
- traffic.service.ts
- FrictionBoard.tsx

close #32 